### PR TITLE
pin importlib_metadata package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ filelock==3.0.12
 flake8==3.7.8
 flake8-colors==0.1.6
 idna==2.8
-importlib-metadata==0.23
+importlib_metadata==1.6.0  # from kombu
 isort==4.3.21
 kombu==4.6.11
 lazy-object-proxy==1.4.2


### PR DESCRIPTION
why: kombu use this library without pinning, and the latest version
(5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version